### PR TITLE
fix: restaurar odontograma interactivo en ficha de cliente

### DIFF
--- a/resources/views/clientes/show.blade.php
+++ b/resources/views/clientes/show.blade.php
@@ -102,16 +102,9 @@
     <div style="display:flex;flex-direction:column;gap:1.5rem;">
 
         {{-- ODONTOGRAMA ──────────────────────────────────────────────────────── --}}
-        @include('components.dentadura', ['cliente' => $cliente, 'showLegend' => true])
-
-        @if(auth()->user()->isGestor())
-        <div style="text-align:center;margin-top:1rem;">
-            <button class="btn btn-primary btn-sm" onclick="abrirModalCita()">✏️ Editar dentadura</button>
-            <p style="font-size:.78rem;color:var(--texto-med);margin-top:.75rem;">
-                Haz clic en cualquier diente para cambiar su estado.
-            </p>
-        </div>
-        @endif
+        <div class="card odontograma">
+            <div class="card-header">
+                <h3 class="card-title">🦷 Odontograma</h3>
                 <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
                     @foreach(App\Models\Dentadura::ESTADOS as $key => $est)
                     <div class="leyenda-item">


### PR DESCRIPTION
## Resumen

- **Bug:** Durante la modernización de UI, se añadió `@include('components.dentadura')` (componente SVG de solo lectura) pero se eliminó accidentalmente el `<div class="card odontograma">` que envolvía el odontograma original interactivo. Esto dejó la leyenda, las dos arcadas y todos los `onclick` de edición de dientes sin contenedor padre, rompiendo la estructura HTML y el flujo de edición.
- **Bug adicional:** El botón "Editar dentadura" llamaba a `abrirModalCita()` en lugar del modal de dientes.
- **Fix:** Se elimina el `@include` de solo lectura, se elimina el botón incorrecto y se restaura el wrapper correcto con `card-header`, leyenda y arcadas — todo dentro de `<div class="card odontograma">`.

## Cambios

- `resources/views/clientes/show.blade.php` — Eliminado `@include('components.dentadura', ...)` y botón erróneo; restaurado wrapper `<div class="card odontograma">` con su `card-header`

## Flujo restaurado

1. Gestor abre ficha de cliente → ve el odontograma con arcadas superior e inferior
2. Hace clic en cualquier diente → `abrirModalDiente(num, estado, notas)`
3. Cambia estado/notas → `guardarDiente()` → `POST /clientes/{id}/dentadura`
4. La página recarga mostrando el estado actualizado

## Test plan

- [ ] Abrir ficha de un cliente → el odontograma se renderiza correctamente con leyenda y ambas arcadas
- [ ] Como gestor, hacer clic en un diente → se abre el modal de edición con el estado actual
- [ ] Cambiar el estado y guardar → la página recarga y el diente muestra el nuevo estado
- [ ] Como cliente (no gestor), los dientes no son clicables
- [ ] El modal "Nueva cita" se abre solo con el botón `+ Cita`, no con ningún diente

🤖 Generated with [Claude Code](https://claude.com/claude-code)