### PR TITLE
v1.1 — API Android completa, modal calendario y documentación

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ match(true) {
   - `GET /api/mis-citas` — Own appointments
   - `POST /api/citas` — Create appointment
   - **Gestor only** (gestor middleware): `GET /api/clientes`, `GET /api/citas/mes`, `PATCH /api/citas/{id}/estado`
-  - **Gestor or owner** (gestor.o.propietario middleware): `GET /api/clientes/{id}`, `GET /api/clientes/{id}/historial`
+  - **Gestor or owner** (gestor.o.propietario middleware): `GET /api/clientes/{id}`, `GET /api/clientes/{id}/historial`, `GET /api/clientes/{id}/dentadura`
 
 ### Scheduled Tasks (`routes/console.php`)
 - **Daily at 09:00** — Sends push notifications for next-day appointments (`recordatorio_enviado = false`, status confirmada/pendiente)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ php artisan key:generate
 # Database (create MySQL database named 'clinica_mula' first)
 php artisan migrate --seed
 
+# Demo data — 7 patients with history, appointments and odontogram (dev only, never run in production)
+php artisan db:seed --class=DemoClientesSeeder
+
 # Code formatting (Laravel Pint)
 php artisan pint
 

--- a/app/Http/Controllers/Api/CitaApiController.php
+++ b/app/Http/Controllers/Api/CitaApiController.php
@@ -63,8 +63,8 @@ class CitaApiController extends Controller
 
     public function mes(Request $request): JsonResponse
     {
-        $year  = $request->get('year',  now()->year);
-        $month = $request->get('month', now()->month);
-        return response()->json($this->citaService->citasDelMes($year, $month));
+        $start = $request->get('start', now()->startOfMonth()->toDateString());
+        $end   = $request->get('end',   now()->endOfMonth()->addDay()->toDateString());
+        return response()->json($this->citaService->citasPorRango($start, $end));
     }
 }

--- a/app/Http/Controllers/Api/CitaApiController.php
+++ b/app/Http/Controllers/Api/CitaApiController.php
@@ -61,6 +61,26 @@ class CitaApiController extends Controller
         return response()->json($cita->load('cliente'));
     }
 
+    public function update(Request $request, Cita $cita): JsonResponse
+    {
+        $data = $request->validate([
+            'fecha_hora'       => 'sometimes|date',
+            'duracion_minutos' => 'sometimes|integer|min:15|max:240',
+            'motivo'           => 'sometimes|string|max:200',
+            'estado'           => 'sometimes|in:pendiente,confirmada,cancelada,realizada,no_presentado',
+            'notas'            => 'nullable|string',
+        ]);
+
+        $cita->update($data);
+        return response()->json($cita->fresh('cliente'));
+    }
+
+    public function destroy(Cita $cita): JsonResponse
+    {
+        $cita->delete();
+        return response()->json(['ok' => true]);
+    }
+
     public function mes(Request $request): JsonResponse
     {
         $start = $request->get('start', now()->startOfMonth()->toDateString());

--- a/app/Http/Controllers/Api/ClienteApiController.php
+++ b/app/Http/Controllers/Api/ClienteApiController.php
@@ -29,4 +29,10 @@ class ClienteApiController extends Controller
         $historial = $cliente->historialClinico()->paginate(20);
         return response()->json($historial);
     }
+
+    public function dentadura(Request $request, Cliente $cliente): JsonResponse
+    {
+        $dentadura = $cliente->dentadura()->orderBy('num_diente')->get();
+        return response()->json($dentadura);
+    }
 }

--- a/app/Http/Controllers/Api/ClienteApiController.php
+++ b/app/Http/Controllers/Api/ClienteApiController.php
@@ -3,12 +3,19 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreClienteRequest;
+use App\Http\Requests\UpdateClienteRequest;
 use App\Models\Cliente;
+use App\Models\Dentadura;
+use App\Services\DentaduraService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class ClienteApiController extends Controller
 {
+    public function __construct(private DentaduraService $dentaduraService) {}
+
     public function index(Request $request): JsonResponse
     {
         $clientes = Cliente::query()
@@ -19,9 +26,43 @@ class ClienteApiController extends Controller
         return response()->json($clientes);
     }
 
+    public function store(StoreClienteRequest $request): JsonResponse
+    {
+        $cliente = DB::transaction(function () use ($request) {
+            $cliente = Cliente::create($request->validated());
+            $cliente->num_filiacion = $cliente->generarNumFiliacion();
+            $cliente->save();
+
+            $dientes = array_merge(Dentadura::DIENTES_SUPERIORES, Dentadura::DIENTES_INFERIORES);
+            foreach ($dientes as $num) {
+                Dentadura::create([
+                    'cliente_id'          => $cliente->id,
+                    'num_diente'          => (string) $num,
+                    'estado_pieza'        => 'presente',
+                    'fecha_actualizacion' => now(),
+                ]);
+            }
+            return $cliente;
+        });
+
+        return response()->json($cliente->fresh(), 201);
+    }
+
     public function show(Request $request, Cliente $cliente): JsonResponse
     {
         return response()->json($cliente->load(['historialClinico', 'dentadura', 'citasFuturas']));
+    }
+
+    public function update(UpdateClienteRequest $request, Cliente $cliente): JsonResponse
+    {
+        $cliente->update($request->validated());
+        return response()->json($cliente->fresh());
+    }
+
+    public function destroy(Cliente $cliente): JsonResponse
+    {
+        $cliente->delete();
+        return response()->json(['ok' => true]);
     }
 
     public function historial(Request $request, Cliente $cliente): JsonResponse
@@ -34,5 +75,33 @@ class ClienteApiController extends Controller
     {
         $dentadura = $cliente->dentadura()->orderBy('num_diente')->get();
         return response()->json($dentadura);
+    }
+
+    public function actualizarDentadura(Request $request, Cliente $cliente): JsonResponse
+    {
+        $estadosPieza = implode(',', array_keys(Dentadura::ESTADOS_PIEZA));
+        $estadosCara  = 'sano,' . implode(',', array_keys(Dentadura::ESTADOS_CARA));
+
+        $data = $request->validate([
+            'dientes'                   => 'required|array',
+            'dientes.*.num_diente'      => 'required|string',
+            'dientes.*.estado_pieza'    => "nullable|in:{$estadosPieza}",
+            'dientes.*.cara_vestibular' => "nullable|in:{$estadosCara}",
+            'dientes.*.cara_lingual'    => "nullable|in:{$estadosCara}",
+            'dientes.*.cara_mesial'     => "nullable|in:{$estadosCara}",
+            'dientes.*.cara_distal'     => "nullable|in:{$estadosCara}",
+            'dientes.*.cara_oclusal'    => "nullable|in:{$estadosCara}",
+            'dientes.*.notas'           => 'nullable|string',
+        ]);
+
+        foreach ($data['dientes'] as $dienteData) {
+            $diente = Dentadura::firstOrCreate(
+                ['cliente_id' => $cliente->id, 'num_diente' => $dienteData['num_diente']],
+                ['fecha_actualizacion' => now()]
+            );
+            $this->dentaduraService->actualizarDiente($diente, $dienteData);
+        }
+
+        return response()->json(['ok' => true, 'message' => 'Dentadura actualizada.']);
     }
 }

--- a/app/Http/Controllers/Api/HistorialApiController.php
+++ b/app/Http/Controllers/Api/HistorialApiController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreHistorialRequest;
+use App\Http\Requests\UpdateHistorialRequest;
+use App\Models\Cliente;
+use App\Models\HistorialClinico;
+use Illuminate\Http\JsonResponse;
+
+class HistorialApiController extends Controller
+{
+    public function store(StoreHistorialRequest $request, Cliente $cliente): JsonResponse
+    {
+        $data = $request->validated();
+        $data['cliente_id'] = $cliente->id;
+        $data['gestor_id']  = $request->user()->id;
+        $historial = HistorialClinico::create($data);
+        return response()->json($historial, 201);
+    }
+
+    public function update(UpdateHistorialRequest $request, HistorialClinico $historial): JsonResponse
+    {
+        $historial->update($request->validated());
+        return response()->json($historial->fresh());
+    }
+
+    public function destroy(HistorialClinico $historial): JsonResponse
+    {
+        $historial->delete();
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Http/Controllers/CitaController.php
+++ b/app/Http/Controllers/CitaController.php
@@ -87,10 +87,10 @@ class CitaController extends Controller
 
     // ─── Eliminar ─────────────────────────────────────────────────────────────
 
-    public function destroy(Cita $cita)
+    public function destroy(Request $request, Cita $cita)
     {
         $cita->delete();
-        if (request()->expectsJson()) {
+        if ($request->expectsJson()) {
             return response()->json(['ok' => true]);
         }
         return back()->with('success', 'Cita eliminada.');

--- a/app/Http/Controllers/CitaController.php
+++ b/app/Http/Controllers/CitaController.php
@@ -90,6 +90,9 @@ class CitaController extends Controller
     public function destroy(Cita $cita)
     {
         $cita->delete();
+        if (request()->expectsJson()) {
+            return response()->json(['ok' => true]);
+        }
         return back()->with('success', 'Cita eliminada.');
     }
 

--- a/app/Models/Cita.php
+++ b/app/Models/Cita.php
@@ -83,10 +83,4 @@ class Cita extends Model
                      ->orderBy('fecha_hora');
     }
 
-    public function scopeDelMes($query, int $year, int $month)
-    {
-        return $query->whereYear('fecha_hora', $year)
-                     ->whereMonth('fecha_hora', $month)
-                     ->orderBy('fecha_hora');
-    }
 }

--- a/app/Services/CitaService.php
+++ b/app/Services/CitaService.php
@@ -40,6 +40,8 @@ class CitaService
                 'end'            => $c->fecha_hora->addMinutes($c->duracion_minutos)->toIso8601String(),
                 'color'          => $c->estado_color,
                 'estado'         => $c->estado,
+                'motivo'         => $c->motivo,
+                'notas'          => $c->notas,
                 'cliente_id'     => $c->cliente_id,
                 'cliente_nombre' => $c->cliente->nombre_completo,
             ]);

--- a/app/Services/CitaService.php
+++ b/app/Services/CitaService.php
@@ -37,7 +37,7 @@ class CitaService
                 'id'             => $c->id,
                 'title'          => $c->cliente->nombre_completo . ' — ' . $c->motivo,
                 'start'          => $c->fecha_hora->toIso8601String(),
-                'end'            => $c->fecha_hora->addMinutes($c->duracion_minutos)->toIso8601String(),
+                'end'            => $c->fecha_hora->copy()->addMinutes($c->duracion_minutos)->toIso8601String(),
                 'color'          => $c->estado_color,
                 'estado'         => $c->estado,
                 'motivo'         => $c->motivo,

--- a/app/Services/CitaService.php
+++ b/app/Services/CitaService.php
@@ -44,21 +44,4 @@ class CitaService
                 'cliente_nombre' => $c->cliente->nombre_completo,
             ]);
     }
-
-    public function citasDelMes(int $year, int $month): Collection
-    {
-        return Cita::with('cliente:id,apellidos,nombre')
-            ->delMes($year, $month)
-            ->get()
-            ->map(fn($c) => [
-                'id'             => $c->id,
-                'title'          => $c->cliente->nombre_completo . ' — ' . $c->motivo,
-                'start'          => $c->fecha_hora->toIso8601String(),
-                'end'            => $c->fecha_hora->addMinutes($c->duracion_minutos)->toIso8601String(),
-                'color'          => $c->estado_color,
-                'estado'         => $c->estado,
-                'cliente_id'     => $c->cliente_id,
-                'cliente_nombre' => $c->cliente->nombre_completo,
-            ]);
-    }
 }

--- a/docs/api-mobile-spec.md
+++ b/docs/api-mobile-spec.md
@@ -1,0 +1,1035 @@
+# Clínica Dental Mula — Especificación API para App Móvil
+
+**Versión del backend:** 1.0  
+**Base URL (producción):** `https://tudominio.com/api`  
+**Base URL (desarrollo):** `http://127.0.0.1:8080/api`  
+**Autenticación:** Laravel Sanctum — Bearer Token  
+**Formato:** JSON (`Content-Type: application/json`, `Accept: application/json`)
+
+---
+
+## Índice
+
+1. [Autenticación](#1-autenticación)
+2. [Roles y permisos](#2-roles-y-permisos)
+3. [Notificaciones push (FCM)](#3-notificaciones-push-fcm)
+4. [Pacientes (Clientes)](#4-pacientes-clientes)
+5. [Historial clínico](#5-historial-clínico)
+6. [Odontograma (Dentadura)](#6-odontograma-dentadura)
+7. [Citas](#7-citas)
+8. [Modelos de datos](#8-modelos-de-datos)
+9. [Catálogos y enumerados](#9-catálogos-y-enumerados)
+10. [Gestión de errores](#10-gestión-de-errores)
+11. [Reglas de negocio](#11-reglas-de-negocio)
+
+---
+
+## 1. Autenticación
+
+### 1.1 Login
+
+```
+POST /api/login
+```
+
+No requiere token. Devuelve un Bearer Token de Sanctum válido hasta que se llame a logout.
+
+**Request:**
+```json
+{
+  "email": "admin@clinicamula.es",
+  "password": "Admin1234!"
+}
+```
+
+**Response 200:**
+```json
+{
+  "token": "1|abc123...",
+  "user": {
+    "id": 1,
+    "name": "Dr. García",
+    "email": "admin@clinicamula.es",
+    "role": "gestor"
+  }
+}
+```
+
+**Errores:**
+- `401` — Credenciales incorrectas
+- `403` — Cuenta desactivada (`activo = false`)
+- `422` — Validación (email requerido, password requerido)
+
+El campo `role` determina qué funcionalidades mostrar en la app (ver sección 2).
+
+---
+
+### 1.2 Logout
+
+```
+POST /api/logout
+Authorization: Bearer {token}
+```
+
+Invalida el token actual en servidor. La app debe eliminar el token almacenado localmente.
+
+**Response 200:**
+```json
+{ "ok": true }
+```
+
+---
+
+### 1.3 Gestión del token en la app
+
+- Guardar el token en almacenamiento seguro (Keychain / EncryptedSharedPreferences).
+- Incluirlo en todas las peticiones como header: `Authorization: Bearer {token}`.
+- Ante una respuesta `401`, redirigir a la pantalla de login y limpiar el token almacenado.
+- No hay refresh token — si el token expira o es invalidado, el usuario debe volver a loguearse.
+
+---
+
+## 2. Roles y permisos
+
+El sistema tiene dos roles: **`gestor`** y **`cliente`**.
+
+| Acción | gestor | cliente |
+|--------|--------|---------|
+| Listar todos los pacientes | ✅ | ❌ |
+| Buscar pacientes | ✅ | ❌ |
+| Ver perfil de cualquier paciente | ✅ | ❌ |
+| Ver su propio perfil | ✅ | ✅ |
+| Crear paciente | ✅ | ❌ |
+| Editar paciente | ✅ | ❌ |
+| Eliminar paciente | ✅ | ❌ |
+| Ver historial de cualquier paciente | ✅ | ❌ |
+| Ver su propio historial | ✅ | ✅ |
+| Crear/editar/eliminar historial | ✅ | ❌ |
+| Ver odontograma de cualquier paciente | ✅ | ❌ |
+| Ver su propio odontograma | ✅ | ✅ |
+| Actualizar odontograma | ✅ | ❌ |
+| Ver todas las citas (calendario) | ✅ | ❌ |
+| Ver sus propias citas | ✅ | ✅ |
+| Crear cita (para cualquier paciente) | ✅ | ❌ |
+| Crear cita (para sí mismo) | ❌ | ✅ |
+| Editar cita completa | ✅ | ❌ |
+| Cambiar estado de cita | ✅ | ❌ |
+| Eliminar cita | ✅ | ❌ |
+
+Un usuario `cliente` solo puede acceder a sus propios datos: su ficha, historial, odontograma y citas. Intentar acceder a datos de otro paciente devuelve `403`.
+
+---
+
+## 3. Notificaciones push (FCM)
+
+### 3.1 Registrar token FCM
+
+Debe llamarse tras el login y cada vez que el sistema operativo entregue un nuevo token FCM.
+
+```
+POST /api/dispositivo/token
+Authorization: Bearer {token}
+```
+
+**Request:**
+```json
+{
+  "token_fcm": "dkj3h4kj2h3k4j2h3k4...",
+  "plataforma": "android"
+}
+```
+
+| Campo | Tipo | Requerido | Valores |
+|-------|------|-----------|---------|
+| `token_fcm` | string | ✅ | Token FCM del dispositivo |
+| `plataforma` | string | ❌ | `android` (por defecto), `ios` |
+
+**Response 200:**
+```json
+{ "ok": true }
+```
+
+---
+
+### 3.2 Notificaciones que envía el servidor
+
+El backend envía notificaciones automáticamente en estos eventos:
+
+| Evento | Disparador | Destinatario |
+|--------|-----------|--------------|
+| `cita_creada` | Gestor crea una cita para un paciente | El paciente |
+| `recordatorio` | Tarea programada — 09:00 del día anterior | Pacientes con cita confirmada/pendiente al día siguiente |
+
+**Estructura del payload FCM recibido:**
+```json
+{
+  "notification": {
+    "title": "Nueva cita registrada",
+    "body": "Tu cita para el 15/05/2026 10:00 ha sido registrada. Motivo: Revisión"
+  },
+  "data": {
+    "tipo": "cita_creada",
+    "cita_id": "42"
+  }
+}
+```
+
+**Tipos de notificación (`data.tipo`):**
+
+| Tipo | Acción sugerida en la app |
+|------|--------------------------|
+| `cita_creada` | Navegar a detalle de la cita (`cita_id`) |
+| `recordatorio` | Navegar a detalle de la cita (`cita_id`) |
+
+---
+
+## 4. Pacientes (Clientes)
+
+### 4.1 Listar pacientes
+
+```
+GET /api/clientes
+Authorization: Bearer {token}    (gestor)
+```
+
+Soporta búsqueda por texto y paginación.
+
+**Query params opcionales:**
+
+| Param | Tipo | Descripción |
+|-------|------|-------------|
+| `buscar` | string | Busca en apellidos, nombre, num_filiacion y teléfono |
+| `page` | integer | Página (50 resultados por página) |
+
+**Response 200:**
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "num_filiacion": "MUL-00001",
+      "apellidos": "García López",
+      "nombre": "Juan",
+      "edad": 35,
+      "profesion": "Ingeniero",
+      "direccion": "Calle Mayor 1",
+      "cp": "30170",
+      "telefono": "600123456",
+      "observaciones": null,
+      "user_id": null,
+      "created_at": "2026-01-01T10:00:00.000000Z",
+      "updated_at": "2026-01-01T10:00:00.000000Z"
+    }
+  ],
+  "current_page": 1,
+  "last_page": 3,
+  "per_page": 50,
+  "total": 120
+}
+```
+
+---
+
+### 4.2 Ver perfil de un paciente
+
+```
+GET /api/clientes/{id}
+Authorization: Bearer {token}    (gestor o el propio paciente)
+```
+
+**Response 200:**
+```json
+{
+  "id": 1,
+  "num_filiacion": "MUL-00001",
+  "apellidos": "García López",
+  "nombre": "Juan",
+  "edad": 35,
+  "profesion": "Ingeniero",
+  "direccion": "Calle Mayor 1",
+  "cp": "30170",
+  "telefono": "600123456",
+  "observaciones": null,
+  "user_id": 5,
+  "historial_clinico": [...],
+  "dentadura": [...],
+  "citas_futuras": [...]
+}
+```
+
+---
+
+### 4.3 Crear paciente
+
+```
+POST /api/clientes
+Authorization: Bearer {token}    (gestor)
+```
+
+Al crear un paciente, el backend inicializa automáticamente los 32 dientes adultos como `presente` en el odontograma.
+
+**Request:**
+```json
+{
+  "apellidos": "García López",
+  "nombre": "Juan",
+  "edad": 35,
+  "profesion": "Ingeniero",
+  "direccion": "Calle Mayor 1",
+  "cp": "30170",
+  "telefono": "600123456",
+  "observaciones": "Alérgico a la penicilina"
+}
+```
+
+| Campo | Tipo | Requerido |
+|-------|------|-----------|
+| `apellidos` | string (max 100) | ✅ |
+| `nombre` | string (max 100) | ✅ |
+| `edad` | integer (0–150) | ❌ |
+| `profesion` | string (max 100) | ❌ |
+| `direccion` | string (max 200) | ❌ |
+| `cp` | string (max 10) | ❌ |
+| `telefono` | string (max 20) | ❌ |
+| `observaciones` | string | ❌ |
+
+**Response 201:** Devuelve el paciente recién creado con `num_filiacion` asignado (formato `MUL-00001`).
+
+---
+
+### 4.4 Actualizar paciente
+
+```
+PUT /api/clientes/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Los campos son los mismos que en la creación. Todos son requeridos en PUT (enviar los valores actuales para los que no cambien).
+
+**Response 200:** Devuelve el paciente actualizado.
+
+---
+
+### 4.5 Eliminar paciente
+
+```
+DELETE /api/clientes/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Soft delete: el registro no se borra físicamente. Los datos históricos se conservan.
+
+**Response 200:**
+```json
+{ "ok": true }
+```
+
+---
+
+## 5. Historial clínico
+
+El historial clínico es una lista de registros asociados a un paciente. Cada registro representa una visita o tratamiento.
+
+### 5.1 Listar historial de un paciente
+
+```
+GET /api/clientes/{id}/historial
+Authorization: Bearer {token}    (gestor o el propio paciente)
+```
+
+Devuelve los registros ordenados por fecha descendente (año, mes, día), paginados (20 por página).
+
+**Response 200:**
+```json
+{
+  "data": [
+    {
+      "id": 10,
+      "cliente_id": 1,
+      "gestor_id": 2,
+      "dia": 10,
+      "mes": 5,
+      "anio": 2026,
+      "signo": "Dolor leve",
+      "diagnostico": "Caries en diente 16",
+      "num_sesiones": 2,
+      "importe": "150.00",
+      "tratamiento_realizado": "Obturación con composite",
+      "recibo": "REC-001",
+      "debe": "150.00",
+      "haber": "150.00",
+      "saldo": "0.00",
+      "created_at": "2026-05-10T10:00:00.000000Z",
+      "updated_at": "2026-05-10T10:00:00.000000Z"
+    }
+  ],
+  "current_page": 1,
+  "last_page": 1,
+  "per_page": 20,
+  "total": 1
+}
+```
+
+**Nota sobre `saldo`:** Se calcula automáticamente como `debe - haber`. No enviarlo al crear o actualizar.
+
+---
+
+### 5.2 Crear registro de historial
+
+```
+POST /api/clientes/{id}/historial
+Authorization: Bearer {token}    (gestor)
+```
+
+**Request:**
+```json
+{
+  "dia": 10,
+  "mes": 5,
+  "anio": 2026,
+  "signo": "Dolor leve",
+  "diagnostico": "Caries en diente 16",
+  "num_sesiones": 2,
+  "importe": 150.00,
+  "tratamiento_realizado": "Obturación con composite",
+  "recibo": "REC-001",
+  "debe": 150.00,
+  "haber": 150.00
+}
+```
+
+| Campo | Tipo | Requerido | Notas |
+|-------|------|-----------|-------|
+| `dia` | integer (1–31) | ✅ | Se valida que la fecha sea real (`checkdate`) |
+| `mes` | integer (1–12) | ✅ | |
+| `anio` | integer (1900–2100) | ✅ | |
+| `diagnostico` | string | ✅ | |
+| `signo` | string (max 50) | ❌ | |
+| `num_sesiones` | integer (≥1) | ❌ | |
+| `importe` | decimal (≥0) | ❌ | |
+| `tratamiento_realizado` | string | ❌ | |
+| `recibo` | string (max 50) | ❌ | |
+| `debe` | decimal (≥0) | ❌ | Lo que el paciente debe |
+| `haber` | decimal (≥0) | ❌ | Lo que el paciente ha pagado |
+
+**Response 201:** Devuelve el registro creado (con `saldo` calculado).
+
+**Error `422`:** Si la fecha no es válida (ej. 31 de febrero), el error vendrá en el campo `dia`.
+
+---
+
+### 5.3 Actualizar registro de historial
+
+```
+PUT /api/historial/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Los campos son los mismos que en la creación.
+
+**Response 200:** Devuelve el registro actualizado.
+
+---
+
+### 5.4 Eliminar registro de historial
+
+```
+DELETE /api/historial/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Hard delete (se elimina definitivamente).
+
+**Response 200:**
+```json
+{ "ok": true }
+```
+
+---
+
+## 6. Odontograma (Dentadura)
+
+### 6.1 Notación FDI (ISO 3950)
+
+El sistema usa numeración FDI. Cada diente tiene un número de 2 dígitos:
+
+```
+Arcada superior (adulto):
+  ← Izquierda del paciente    Derecha del paciente →
+  18 17 16 15 14 13 12 11 | 21 22 23 24 25 26 27 28
+
+Arcada inferior (adulto):
+  48 47 46 45 44 43 42 41 | 31 32 33 34 35 36 37 38
+```
+
+**Tipo de diente por número:**
+
+| Tipo | Números FDI |
+|------|-------------|
+| Incisivo | x1, x2 (11,12,21,22,31,32,41,42) |
+| Canino | x3 (13,23,33,43) |
+| Premolar | x4, x5 (14,15,24,25,34,35,44,45) |
+| Molar | x6, x7, x8 (16,17,18,26,27,28,36,37,38,46,47,48) |
+
+**Caras del diente:**
+
+| Cara | Descripción | Tiene oclusal |
+|------|-------------|---------------|
+| `vestibular` | Exterior (labial/bucal) | Todos |
+| `lingual` | Interior (lingual/palatino) | Todos |
+| `mesial` | Lateral hacia línea media | Todos |
+| `distal` | Lateral opuesto a línea media | Todos |
+| `oclusal` | Superficie de masticación | Solo premolares y molares |
+
+Los incisivos y caninos **no tienen cara oclusal**.
+
+---
+
+### 6.2 Ver odontograma de un paciente
+
+```
+GET /api/clientes/{id}/dentadura
+Authorization: Bearer {token}    (gestor o el propio paciente)
+```
+
+**Response 200:** Array con los 32 registros del odontograma, ordenados por `num_diente`.
+
+```json
+[
+  {
+    "id": 1,
+    "cliente_id": 1,
+    "num_diente": "11",
+    "estado_pieza": null,
+    "cara_vestibular": null,
+    "cara_lingual": null,
+    "cara_mesial": null,
+    "cara_distal": null,
+    "cara_oclusal": null,
+    "notas": null,
+    "fecha_actualizacion": "2026-01-01"
+  },
+  {
+    "id": 2,
+    "cliente_id": 1,
+    "num_diente": "16",
+    "estado_pieza": "corona",
+    "cara_vestibular": null,
+    "cara_lingual": "caries",
+    "cara_mesial": null,
+    "cara_distal": null,
+    "cara_oclusal": "obturacion",
+    "notas": "Revisada en 2025",
+    "fecha_actualizacion": "2026-03-15"
+  }
+]
+```
+
+**Importante — valor `null`:**
+- `estado_pieza = null` significa **presente** (diente sano/normal).
+- Cualquier cara `= null` significa **sana** (sin patología).
+
+Al renderizar, tratar `null` como `"presente"` para estado de pieza y como `"sano"` para caras.
+
+---
+
+### 6.3 Actualizar odontograma
+
+```
+POST /api/clientes/{id}/dentadura
+Authorization: Bearer {token}    (gestor)
+```
+
+Enviar solo los dientes que se quieran actualizar. Se usa upsert: si el diente no existe se crea, si existe se actualiza.
+
+**Request:**
+```json
+{
+  "dientes": [
+    {
+      "num_diente": "16",
+      "estado_pieza": "corona",
+      "cara_vestibular": null,
+      "cara_lingual": "caries",
+      "cara_mesial": null,
+      "cara_distal": null,
+      "cara_oclusal": "obturacion",
+      "notas": "Revisada en 2025"
+    },
+    {
+      "num_diente": "26",
+      "estado_pieza": "ausente"
+    }
+  ]
+}
+```
+
+| Campo | Tipo | Requerido |
+|-------|------|-----------|
+| `dientes` | array | ✅ |
+| `dientes[].num_diente` | string | ✅ |
+| `dientes[].estado_pieza` | string\|null | ❌ |
+| `dientes[].cara_vestibular` | string\|null | ❌ |
+| `dientes[].cara_lingual` | string\|null | ❌ |
+| `dientes[].cara_mesial` | string\|null | ❌ |
+| `dientes[].cara_distal` | string\|null | ❌ |
+| `dientes[].cara_oclusal` | string\|null | ❌ |
+| `dientes[].notas` | string\|null | ❌ |
+
+Los valores `"sano"` y `"presente"` se almacenan como `null` internamente. Puedes enviar `null` directamente.
+
+**Response 200:**
+```json
+{ "ok": true, "message": "Dentadura actualizada." }
+```
+
+---
+
+## 7. Citas
+
+### 7.1 Mis citas (paciente)
+
+```
+GET /api/mis-citas
+Authorization: Bearer {token}    (cliente)
+```
+
+Solo para usuarios con rol `cliente`. Devuelve las citas del paciente vinculado a su cuenta.
+
+**Response 200:**
+```json
+{
+  "proximas": [
+    {
+      "id": 5,
+      "cliente_id": 1,
+      "gestor_id": 2,
+      "fecha_hora": "2026-06-15T10:00:00.000000Z",
+      "duracion_minutos": 45,
+      "motivo": "Revisión semestral",
+      "estado": "confirmada",
+      "notas": null,
+      "recordatorio_enviado": false,
+      "gestor": {
+        "id": 2,
+        "name": "Dr. García"
+      }
+    }
+  ],
+  "anteriores": [...]
+}
+```
+
+- `proximas`: citas futuras con estado `pendiente` o `confirmada`, ordenadas por fecha ascendente.
+- `anteriores`: las últimas 20 citas pasadas, ordenadas por fecha descendente.
+
+Si el usuario no tiene ficha de paciente vinculada, devuelve `404`.
+
+---
+
+### 7.2 Citas del mes (gestor — calendario)
+
+```
+GET /api/citas/mes
+Authorization: Bearer {token}    (gestor)
+```
+
+Devuelve citas en un rango de fechas formateadas para FullCalendar. Útil para mostrar un calendario mensual en la app de gestor.
+
+**Query params opcionales:**
+
+| Param | Tipo | Descripción | Por defecto |
+|-------|------|-------------|-------------|
+| `start` | date (YYYY-MM-DD) | Inicio del rango | Primer día del mes actual |
+| `end` | date (YYYY-MM-DD) | Fin del rango (exclusivo) | Primer día del mes siguiente |
+
+**Response 200:** Array de eventos.
+```json
+[
+  {
+    "id": 5,
+    "title": "García López, Juan — Revisión",
+    "start": "2026-05-15T10:00:00+02:00",
+    "end": "2026-05-15T10:45:00+02:00",
+    "color": "#3b82f6",
+    "extendedProps": {
+      "estado": "confirmada",
+      "motivo": "Revisión semestral",
+      "notas": null,
+      "cliente_id": 1,
+      "cliente_nombre": "García López, Juan"
+    }
+  }
+]
+```
+
+---
+
+### 7.3 Crear cita
+
+```
+POST /api/citas
+Authorization: Bearer {token}    (gestor o cliente)
+```
+
+**El comportamiento varía según el rol:**
+
+| Campo | Gestor | Cliente |
+|-------|--------|---------|
+| `cliente_id` | Requerido (especifica el paciente) | Ignorado (se usa el suyo propio) |
+| `estado` inicial | `confirmada` | `pendiente` |
+| Notificación push | Sí, al paciente | No |
+
+**Request (gestor):**
+```json
+{
+  "cliente_id": 1,
+  "fecha_hora": "2026-06-15T10:00:00",
+  "duracion_minutos": 45,
+  "motivo": "Revisión semestral",
+  "notas": "Traer radiografías anteriores"
+}
+```
+
+**Request (cliente — omite `cliente_id`):**
+```json
+{
+  "fecha_hora": "2026-06-15T10:00:00",
+  "motivo": "Me duele el diente 16"
+}
+```
+
+| Campo | Tipo | Requerido | Validación |
+|-------|------|-----------|------------|
+| `cliente_id` | integer | Solo gestor | Debe existir en BD |
+| `fecha_hora` | datetime | ✅ | Debe ser en el futuro (`after:now`) |
+| `duracion_minutos` | integer | ❌ | 15–240, por defecto 30 |
+| `motivo` | string (max 200) | ✅ | |
+| `notas` | string | ❌ | |
+
+**Response 201:** La cita creada con el paciente cargado.
+
+**Error `422`:** Si la fecha es pasada o falta el motivo.
+**Error `422`:** Si el cliente no tiene ficha vinculada (solo para usuarios cliente).
+
+---
+
+### 7.4 Actualizar cita completa
+
+```
+PUT /api/citas/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Permite modificar cualquier campo de la cita. Todos son opcionales (`sometimes`).
+
+**Request:**
+```json
+{
+  "fecha_hora": "2026-06-16T11:00:00",
+  "duracion_minutos": 60,
+  "motivo": "Revisión + limpieza",
+  "estado": "confirmada",
+  "notas": "Paciente llegará tarde"
+}
+```
+
+| Campo | Tipo | Validación |
+|-------|------|------------|
+| `fecha_hora` | datetime | Fecha válida |
+| `duracion_minutos` | integer | 15–240 |
+| `motivo` | string (max 200) | |
+| `estado` | string | Valores válidos (ver catálogo) |
+| `notas` | string\|null | |
+
+**Response 200:** La cita actualizada con el paciente cargado.
+
+---
+
+### 7.5 Cambiar estado de cita
+
+```
+PATCH /api/citas/{id}/estado
+Authorization: Bearer {token}    (gestor)
+```
+
+Endpoint específico para cambios de estado en el flujo de trabajo.
+
+**Request:**
+```json
+{
+  "estado": "realizada",
+  "notas": "Tratamiento completado sin incidencias"
+}
+```
+
+| Campo | Tipo | Requerido |
+|-------|------|-----------|
+| `estado` | string | ✅ |
+| `notas` | string | ❌ |
+
+**Response 200:** La cita actualizada con el paciente cargado.
+
+---
+
+### 7.6 Eliminar cita
+
+```
+DELETE /api/citas/{id}
+Authorization: Bearer {token}    (gestor)
+```
+
+Hard delete.
+
+**Response 200:**
+```json
+{ "ok": true }
+```
+
+---
+
+## 8. Modelos de datos
+
+### 8.1 Cliente (Paciente)
+
+```
+id               integer    PK, autoincremental
+num_filiacion    string     Formato "MUL-00001", generado al crear
+apellidos        string     max 100
+nombre           string     max 100
+edad             integer?   0–150
+profesion        string?    max 100
+direccion        string?    max 200
+cp               string?    max 10
+telefono         string?    max 20
+observaciones    text?
+user_id          integer?   FK → users (si tiene cuenta de acceso)
+deleted_at       datetime?  Soft delete
+created_at       datetime
+updated_at       datetime
+```
+
+### 8.2 Cita
+
+```
+id                   integer    PK
+cliente_id           integer    FK → clientes
+gestor_id            integer?   FK → users (gestor que la creó/gestionó)
+fecha_hora           datetime
+duracion_minutos     integer    Por defecto 30
+motivo               string     max 200
+estado               string     pendiente|confirmada|realizada|cancelada|no_presentado
+notas                text?
+recordatorio_enviado boolean    Por defecto false
+created_at           datetime
+updated_at           datetime
+```
+
+### 8.3 HistorialClinico
+
+```
+id                    integer    PK
+cliente_id            integer    FK → clientes
+gestor_id             integer?   FK → users
+dia                   integer    1–31
+mes                   integer    1–12
+anio                  integer
+signo                 string?    max 50
+diagnostico           text
+num_sesiones          integer?
+importe               decimal?   2 decimales
+tratamiento_realizado text?
+recibo                string?    max 50
+debe                  decimal?   2 decimales
+haber                 decimal?   2 decimales
+saldo                 decimal    Auto: debe - haber (no enviar)
+created_at            datetime
+updated_at            datetime
+```
+
+### 8.4 Dentadura (registro por diente)
+
+```
+id                   integer    PK
+cliente_id           integer    FK → clientes
+num_diente           string     Número FDI (ej. "16")
+estado_pieza         string?    null = presente
+cara_vestibular      string?    null = sano
+cara_lingual         string?    null = sano
+cara_mesial          string?    null = sano
+cara_distal          string?    null = sano
+cara_oclusal         string?    null = sano (solo molares/premolares)
+notas                text?
+fecha_actualizacion  date
+created_at           datetime
+updated_at           datetime
+```
+
+### 8.5 User
+
+```
+id       integer    PK
+name     string
+email    string
+role     string     gestor|cliente
+activo   boolean    Por defecto true
+```
+
+---
+
+## 9. Catálogos y enumerados
+
+### 9.1 Estados de cita
+
+| Valor | Etiqueta | Color |
+|-------|----------|-------|
+| `pendiente` | Pendiente | `#f97316` (naranja) |
+| `confirmada` | Confirmada | `#3b82f6` (azul) |
+| `realizada` | Realizada | `#4ade80` (verde) |
+| `cancelada` | Cancelada | `#ef4444` (rojo) |
+| `no_presentado` | No se presentó | `#6b7280` (gris) |
+
+**Flujo de estados:**
+```
+pendiente → confirmada → realizada
+                       → cancelada
+                       → no_presentado
+pendiente → cancelada
+```
+
+### 9.2 Estados de pieza dental (`estado_pieza`)
+
+| Valor | Etiqueta | Color | Icono |
+|-------|----------|-------|-------|
+| `null` / `presente` | Presente | `#4ade80` | ✓ |
+| `ausente` | Ausente | `#6b7280` | ○ |
+| `corona` | Corona | `#a855f7` | ♛ |
+| `puente` | Puente | `#3b82f6` | P |
+| `implante` | Implante | `#eab308` | I |
+| `endodoncia` | Endodoncia | `#f97316` | E |
+| `no_erupcionado` | No erupcionado | `#fef3c7` | ? |
+| `extrac_indicada` | Extracción indicada | `#fca5a5` | ! |
+| `extraido` | Extraído | `#9ca3af` | ✕ |
+| `temporal` | Temporal (deciduo) | `#f9a8d4` | T |
+| `pulpitis` | Pulpitis | `#f97316` | Pu |
+| `necrosis` | Necrosis pulpar | `#1f2937` | N |
+| `apicectomia` | Apicectomía | `#0f766e` | Ap |
+| `incluido` | Incluido/Retenido | `#7c3aed` | R |
+| `supernumerario` | Supernumerario | `#db2777` | S |
+| `movilidad_1` | Movilidad Grado I | `#facc15` | M1 |
+| `movilidad_2` | Movilidad Grado II | `#ea580c` | M2 |
+| `movilidad_3` | Movilidad Grado III | `#b91c1c` | M3 |
+| `carilla` | Carilla | `#93c5fd` | Ca |
+| `pilar_puente` | Pilar de puente | `#a78bfa` | Pp |
+| `pontico` | Póntico de puente | `#c4b5fd` | Po |
+| `prot_removible` | Prótesis removible | `#fb923c` | Pr |
+| `giroversion` | Giroversión | `#84cc16` | G |
+| `migracion` | Migración | `#22d3ee` | → |
+| `diastema` | Diastema | `#e879f9` | ◁▷ |
+| `fluorosis` | Fluorosis | `#a3e635` | F |
+| `agenesia` | Agenesia | `#94a3b8` | ∅ |
+
+### 9.3 Estados de cara dental (`cara_*`)
+
+| Valor | Etiqueta | Color |
+|-------|----------|-------|
+| `null` / `sano` | Sano | `#4ade80` |
+| `caries` | Caries | `#ef4444` |
+| `obturacion` | Obturación | `#f97316` |
+| `fractura` | Fractura | `#a855f7` |
+| `sellante` | Sellante | `#06b6d4` |
+| `desgaste` | Desgaste | `#78716c` |
+| `caries_det` | Caries detenida | `#f59e0b` |
+| `composite` | Composite | `#3b82f6` |
+| `amalgama` | Amalgama | `#64748b` |
+| `erosion` | Erosión | `#d97706` |
+| `tincion` | Tinción | `#92400e` |
+| `fisura` | Fisura | `#374151` |
+| `reconstruccion` | Reconstrucción | `#059669` |
+
+---
+
+## 10. Gestión de errores
+
+### Códigos HTTP
+
+| Código | Significado | Acción en la app |
+|--------|-------------|-----------------|
+| `200` | OK | Procesar respuesta |
+| `201` | Creado | Procesar respuesta, actualizar lista |
+| `401` | No autenticado | Redirigir a login, limpiar token |
+| `403` | Sin permisos | Mostrar mensaje de acceso denegado |
+| `404` | No encontrado | Mostrar error o volver atrás |
+| `422` | Validación fallida | Mostrar errores campo a campo |
+| `500` | Error servidor | Mostrar mensaje genérico |
+
+### Estructura de error de validación (`422`)
+
+```json
+{
+  "message": "The apellidos field is required.",
+  "errors": {
+    "apellidos": ["El campo apellidos es obligatorio."],
+    "fecha_hora": ["La fecha debe ser posterior a ahora."]
+  }
+}
+```
+
+### Estructura de error genérico
+
+```json
+{
+  "message": "Descripción del error."
+}
+```
+
+---
+
+## 11. Reglas de negocio
+
+### Identificador de paciente (`num_filiacion`)
+- Se genera automáticamente al crear el paciente: `MUL-00001`, `MUL-00002`, etc.
+- No puede modificarse una vez asignado.
+
+### Odontograma inicial
+- Al crear un paciente, el backend crea automáticamente los 32 dientes adultos con `estado_pieza = null` (presente).
+- La app no necesita inicializar el odontograma manualmente.
+
+### Valores nulos en odontograma
+- `estado_pieza = null` → mostrar como **presente** (diente normal).
+- `cara_* = null` → mostrar como **sana** (sin patología).
+- Al enviar actualizaciones, se puede enviar `null` para "limpiar" un estado.
+
+### Saldo del historial
+- `saldo = debe - haber`, calculado automáticamente por el servidor.
+- Nunca enviarlo en peticiones de creación/actualización.
+- Un saldo positivo indica deuda del paciente.
+
+### Citas — estados permitidos
+- Un cliente solo puede crear citas para sí mismo con estado `pendiente`.
+- Un gestor crea citas en estado `confirmada`.
+- El cambio de estado lo gestiona el gestor.
+
+### Citas — notificaciones
+- Cuando el gestor crea una cita para un paciente que tiene cuenta de usuario, el servidor envía automáticamente una notificación push.
+- El servidor envía recordatorios a las 09:00 del día anterior para citas con estado `confirmada` o `pendiente`.
+- Si el paciente no tiene la app instalada o no ha registrado un token FCM, las notificaciones simplemente no se entregan (sin error).
+
+### Soft delete de pacientes
+- Los pacientes eliminados no aparecen en listados ni búsquedas.
+- Sus datos históricos (historial, odontograma, citas) se conservan en base de datos.
+- No hay endpoint de restauración en la API actual.
+
+### Sesiones y tokens
+- Los tokens de Sanctum no expiran automáticamente.
+- Cada login genera un token nuevo. Los anteriores siguen siendo válidos hasta que se haga logout.
+- Para multi-dispositivo, cada dispositivo debe hacer su propio login.
+
+---
+
+## Credenciales de prueba (entorno de desarrollo)
+
+| Rol | Email | Contraseña |
+|-----|-------|------------|
+| Gestor | admin@clinicamula.es | Admin1234! |
+| Paciente | paciente@example.com | Cliente1234! |

--- a/docs/superpowers/plans/2026-05-14-modal-detalle-cita.md
+++ b/docs/superpowers/plans/2026-05-14-modal-detalle-cita.md
@@ -1,0 +1,511 @@
+# Modal detalle de cita — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reemplazar el `alert()` del calendario con un modal de flujo rápido que muestre los datos de la cita y permita cambiar estado o eliminarla sin recargar la página.
+
+**Architecture:** Solo frontend (`calendario.blade.php`) más dos pequeños parches de backend: añadir `motivo`/`notas` a los extendedProps del JSON de FullCalendar y devolver JSON desde `CitaController@destroy`. El modal lee los datos del evento FullCalendar en memoria (sin llamada extra al servidor al abrir), envía `PUT` o `DELETE` vía `fetch`, y actualiza el evento directamente con la API de FullCalendar.
+
+**Tech Stack:** Laravel 11, Blade, FullCalendar 6, Vanilla JS, PHPUnit 11
+
+---
+
+## Mapa de ficheros
+
+| Acción | Fichero |
+|--------|---------|
+| Modificar | `app/Services/CitaService.php` — añadir `motivo` y `notas` al mapa de `citasPorRango()` |
+| Modificar | `app/Http/Controllers/CitaController.php` — rama JSON en `destroy()` |
+| Modificar | `tests/Feature/Citas/CitaTest.php` — test JSON destroy |
+| Modificar | `resources/views/citas/calendario.blade.php` — HTML modal, CSS, JS |
+
+---
+
+## Task 1: Preparar backend — extendedProps y destroy JSON
+
+**Files:**
+- Modify: `app/Services/CitaService.php`
+- Modify: `app/Http/Controllers/CitaController.php`
+- Modify: `tests/Feature/Citas/CitaTest.php`
+
+- [ ] **Paso 1: Escribir el test que falla para destroy JSON**
+
+En `tests/Feature/Citas/CitaTest.php`, añadir al final de la clase (antes del `}`):
+
+```php
+public function test_gestor_puede_eliminar_cita_via_json(): void
+{
+    $gestor  = User::factory()->gestor()->create();
+    $cliente = Cliente::factory()->create();
+    $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+
+    $this->actingAs($gestor)
+         ->deleteJson(route('citas.destroy', $cita))
+         ->assertOk()
+         ->assertJson(['ok' => true]);
+
+    $this->assertDatabaseMissing('citas', ['id' => $cita->id]);
+}
+```
+
+- [ ] **Paso 2: Ejecutar el test — verificar que falla**
+
+```bash
+C:/laragon/bin/php/php-8.3.30-Win32-vs16-x64/php.exe vendor/bin/phpunit tests/Feature/Citas/CitaTest.php::test_gestor_puede_eliminar_cita_via_json --no-coverage
+```
+
+Esperado: FAIL — el método devuelve redirect, no JSON.
+
+- [ ] **Paso 3: Añadir rama JSON a `CitaController@destroy`**
+
+En `app/Http/Controllers/CitaController.php`, reemplazar:
+
+```php
+public function destroy(Cita $cita)
+{
+    $cita->delete();
+    return back()->with('success', 'Cita eliminada.');
+}
+```
+
+por:
+
+```php
+public function destroy(Cita $cita)
+{
+    $cita->delete();
+    if (request()->expectsJson()) {
+        return response()->json(['ok' => true]);
+    }
+    return back()->with('success', 'Cita eliminada.');
+}
+```
+
+- [ ] **Paso 4: Añadir `motivo` y `notas` a `citasPorRango()` en `CitaService`**
+
+En `app/Services/CitaService.php`, dentro del `map(...)` de `citasPorRango()`, añadir dos líneas:
+
+```php
+return Cita::with('cliente:id,apellidos,nombre')
+    ->where('fecha_hora', '>=', $start)
+    ->where('fecha_hora', '<',  $end)
+    ->orderBy('fecha_hora')
+    ->get()
+    ->map(fn($c) => [
+        'id'             => $c->id,
+        'title'          => $c->cliente->nombre_completo . ' — ' . $c->motivo,
+        'start'          => $c->fecha_hora->toIso8601String(),
+        'end'            => $c->fecha_hora->addMinutes($c->duracion_minutos)->toIso8601String(),
+        'color'          => $c->estado_color,
+        'estado'         => $c->estado,
+        'motivo'         => $c->motivo,
+        'notas'          => $c->notas,
+        'cliente_id'     => $c->cliente_id,
+        'cliente_nombre' => $c->cliente->nombre_completo,
+    ]);
+```
+
+- [ ] **Paso 5: Ejecutar los tests del área de citas**
+
+```bash
+C:/laragon/bin/php/php-8.3.30-Win32-vs16-x64/php.exe vendor/bin/phpunit tests/Feature/Citas/CitaTest.php --no-coverage
+```
+
+Esperado: todos los tests PASS (incluyendo el nuevo).
+
+- [ ] **Paso 6: Commit**
+
+```bash
+git add app/Services/CitaService.php app/Http/Controllers/CitaController.php tests/Feature/Citas/CitaTest.php
+git commit -m "feat: extendedProps motivo/notas en citasPorRango y JSON en destroy"
+```
+
+---
+
+## Task 2: HTML + CSS del modal de detalle
+
+**Files:**
+- Modify: `resources/views/citas/calendario.blade.php`
+
+- [ ] **Paso 1: Añadir CSS del modal al bloque `@push('styles')`**
+
+Añadir al final del bloque `<style>` existente (antes de `</style>`):
+
+```css
+/* Modal detalle */
+#detalle-header { transition: background .2s; }
+#detalle-header .modal-close { color: rgba(255,255,255,.75); }
+#detalle-header .modal-close:hover { color: #fff; }
+.detalle-fila {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+.detalle-label {
+    color: #64748b;
+    font-size: .82rem;
+    width: 70px;
+    flex-shrink: 0;
+}
+.detalle-valor {
+    font-size: .9rem;
+    color: #1e293b;
+}
+.detalle-seccion {
+    border-top: 1px solid #f1f5f9;
+    padding-top: 14px;
+    margin-top: 14px;
+}
+.detalle-seccion-titulo {
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #94a3b8;
+    margin-bottom: 10px;
+}
+#detalle-botones-estado { display: flex; flex-wrap: wrap; gap: 6px; }
+.detalle-btn-estado {
+    font-size: .8rem;
+    padding: 5px 10px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #1e293b;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: opacity .15s;
+}
+.detalle-btn-estado:hover { opacity: .8; }
+.detalle-btn-estado:disabled { opacity: .5; cursor: not-allowed; }
+#detalle-btn-eliminar {
+    background: #fef2f2;
+    color: #ef4444;
+    border: 1px solid #fecaca;
+    font-size: .82rem;
+    transition: background .15s, color .15s;
+}
+```
+
+- [ ] **Paso 2: Añadir el HTML del modal después del popup de día**
+
+Justo después del bloque `{{-- ── POPUP contextual de día ──── --}}` y antes de `{{-- ── MODAL nueva cita ──── --}}`, insertar:
+
+```html
+{{-- ── MODAL detalle de cita ─────────────────────────────────────────────────── --}}
+<div class="modal-backdrop" id="modal-detalle-cita">
+    <div class="modal" style="max-width:440px;">
+        <div class="modal-header" id="detalle-header">
+            <div>
+                <span id="detalle-estado-badge"
+                      style="font-size:.78rem;opacity:.85;text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:2px;"></span>
+                <span id="detalle-fecha" style="font-weight:600;font-size:.95rem;"></span>
+            </div>
+            <button class="modal-close" id="detalle-close">×</button>
+        </div>
+        <div style="padding:18px 22px 20px;">
+            <div class="detalle-fila">
+                <span class="detalle-label">Paciente</span>
+                <a id="detalle-paciente-link" href="#" target="_blank"
+                   style="font-weight:500;color:var(--primary);font-size:.9rem;text-decoration:none;"></a>
+            </div>
+            <div class="detalle-fila">
+                <span class="detalle-label">Motivo</span>
+                <span id="detalle-motivo" class="detalle-valor"></span>
+            </div>
+            <div class="detalle-fila">
+                <span class="detalle-label">Duración</span>
+                <span id="detalle-duracion" class="detalle-valor"></span>
+            </div>
+            <div class="detalle-fila" style="margin-bottom:0;">
+                <span class="detalle-label">Notas</span>
+                <span id="detalle-notas" class="detalle-valor" style="color:#64748b;font-style:italic;"></span>
+            </div>
+
+            <div class="detalle-seccion">
+                <p class="detalle-seccion-titulo">Cambiar estado</p>
+                <div id="detalle-botones-estado"></div>
+            </div>
+
+            <div class="detalle-seccion" style="display:flex;justify-content:flex-end;">
+                <button id="detalle-btn-eliminar" class="btn">🗑 Eliminar cita</button>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+- [ ] **Paso 3: Commit**
+
+```bash
+git add resources/views/citas/calendario.blade.php
+git commit -m "feat: HTML y CSS del modal de detalle de cita"
+```
+
+---
+
+## Task 3: JS — constantes globales y función `abrirModalDetalle`
+
+**Files:**
+- Modify: `resources/views/citas/calendario.blade.php`
+
+- [ ] **Paso 1: Añadir constantes globales y `abrirModalDetalle` antes de `abrirModalNuevaCita`**
+
+Justo antes de la función `abrirModalNuevaCita` (al final del bloque `<script>`), insertar:
+
+```js
+const COLORES_ESTADO = {
+    pendiente:     '#f97316',
+    confirmada:    '#3b82f6',
+    realizada:     '#4ade80',
+    cancelada:     '#ef4444',
+    no_presentado: '#6b7280',
+};
+
+const LABELS_ESTADO = {
+    pendiente:     'Pendiente',
+    confirmada:    'Confirmada',
+    realizada:     'Realizada',
+    cancelada:     'Cancelada',
+    no_presentado: 'No se presentó',
+};
+
+let citaActual = null;
+
+function abrirModalDetalle(fcEvent) {
+    citaActual = fcEvent;
+    const props  = fcEvent.extendedProps;
+    const estado = props.estado;
+    const color  = COLORES_ESTADO[estado] || '#6b7280';
+
+    document.getElementById('detalle-header').style.background = color;
+    document.getElementById('detalle-estado-badge').textContent = LABELS_ESTADO[estado] || estado;
+
+    const optsDate = { weekday: 'long', day: 'numeric', month: 'long' };
+    const optsTime = { hour: '2-digit', minute: '2-digit' };
+    const fechaStr = fcEvent.start.toLocaleDateString('es-ES', optsDate);
+    const horaIni  = fcEvent.start.toLocaleTimeString('es-ES', optsTime);
+    const horaFin  = fcEvent.end ? fcEvent.end.toLocaleTimeString('es-ES', optsTime) : '';
+    document.getElementById('detalle-fecha').textContent =
+        horaFin ? `${fechaStr} · ${horaIni}–${horaFin}` : `${fechaStr} · ${horaIni}`;
+
+    const link = document.getElementById('detalle-paciente-link');
+    link.textContent = props.cliente_nombre;
+    link.href = `/clientes/${props.cliente_id}`;
+
+    document.getElementById('detalle-motivo').textContent  = props.motivo || '—';
+    document.getElementById('detalle-notas').textContent   = props.notas  || '—';
+
+    const durMin = (fcEvent.end && fcEvent.start)
+        ? Math.round((fcEvent.end - fcEvent.start) / 60000)
+        : null;
+    document.getElementById('detalle-duracion').textContent = durMin ? `${durMin} min` : '—';
+
+    document.getElementById('detalle-botones-estado').innerHTML =
+        Object.entries(LABELS_ESTADO)
+            .filter(([key]) => key !== estado)
+            .map(([key, label]) =>
+                `<button class="detalle-btn-estado" onclick="cambiarEstadoCita('${key}', this)">${label}</button>`
+            ).join('');
+
+    const btnElim = document.getElementById('detalle-btn-eliminar');
+    btnElim.textContent         = '🗑 Eliminar cita';
+    btnElim.disabled            = false;
+    btnElim._confirmPending     = false;
+    btnElim.style.background    = '#fef2f2';
+    btnElim.style.color         = '#ef4444';
+    btnElim.style.border        = '1px solid #fecaca';
+
+    document.getElementById('modal-detalle-cita').classList.add('open');
+}
+```
+
+- [ ] **Paso 2: Reemplazar `alert()` en `eventClick`**
+
+Localizar en el bloque `<script>`:
+
+```js
+        eventClick: function(info) {
+            info.jsEvent.stopPropagation();
+            const e = info.event;
+            const props = e.extendedProps;
+            const partes = e.title.split(' — ');
+            alert([
+                `Paciente: ${props.cliente_nombre}`,
+                `Motivo: ${partes[1] || partes[0]}`,
+                `Estado: ${props.estado}`,
+                `Inicio: ${e.start.toLocaleString('es-ES')}`,
+            ].join('\n'));
+        },
+```
+
+Reemplazar por:
+
+```js
+        eventClick: function(info) {
+            info.jsEvent.stopPropagation();
+            abrirModalDetalle(info.event);
+        },
+```
+
+- [ ] **Paso 3: Commit**
+
+```bash
+git add resources/views/citas/calendario.blade.php
+git commit -m "feat: abrirModalDetalle reemplaza alert() en eventClick"
+```
+
+---
+
+## Task 4: JS — función `cambiarEstadoCita`
+
+**Files:**
+- Modify: `resources/views/citas/calendario.blade.php`
+
+- [ ] **Paso 1: Añadir `cambiarEstadoCita` junto a las otras funciones globales**
+
+Justo después de la función `abrirModalDetalle` (antes de `abrirModalNuevaCita`), insertar:
+
+```js
+function cambiarEstadoCita(nuevoEstado, btn) {
+    if (!citaActual) return;
+    const textoOriginal = btn.textContent;
+    btn.disabled    = true;
+    btn.textContent = 'Guardando…';
+
+    fetch(`/citas/${citaActual.id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type':  'application/json',
+            'Accept':        'application/json',
+            'X-CSRF-TOKEN':  document.querySelector('meta[name="csrf-token"]').content,
+        },
+        body: JSON.stringify({ estado: nuevoEstado }),
+    })
+    .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+    .then(() => {
+        citaActual.setExtendedProp('estado', nuevoEstado);
+        citaActual.setProp('color', COLORES_ESTADO[nuevoEstado] || '#6b7280');
+        document.getElementById('modal-detalle-cita').classList.remove('open');
+    })
+    .catch(() => {
+        btn.disabled    = false;
+        btn.textContent = textoOriginal;
+        alert('No se pudo actualizar la cita. Recarga la página e inténtalo de nuevo.');
+    });
+}
+```
+
+- [ ] **Paso 2: Commit**
+
+```bash
+git add resources/views/citas/calendario.blade.php
+git commit -m "feat: cambiarEstadoCita — PUT fetch + actualización en FullCalendar"
+```
+
+---
+
+## Task 5: JS — cierre de modal y `eliminarCita` (double-confirm)
+
+**Files:**
+- Modify: `resources/views/citas/calendario.blade.php`
+
+- [ ] **Paso 1: Añadir event listeners del modal dentro de `DOMContentLoaded`**
+
+Al final del bloque dentro de `document.addEventListener('DOMContentLoaded', function () { ... });`, justo antes del `});` de cierre, insertar:
+
+```js
+    // ── Modal detalle ─────────────────────────────────────────────────────────
+
+    document.getElementById('detalle-close').addEventListener('click', function() {
+        document.getElementById('modal-detalle-cita').classList.remove('open');
+    });
+
+    document.getElementById('modal-detalle-cita').addEventListener('click', function(e) {
+        if (e.target === this) this.classList.remove('open');
+    });
+
+    document.getElementById('detalle-btn-eliminar').addEventListener('click', function() {
+        if (!citaActual) return;
+
+        if (!this._confirmPending) {
+            this._confirmPending  = true;
+            this.textContent      = '¿Seguro? Clic para confirmar';
+            this.style.background = '#ef4444';
+            this.style.color      = '#fff';
+            this.style.border     = '1px solid #ef4444';
+
+            const btn = this;
+            btn._confirmTimer = setTimeout(() => {
+                btn._confirmPending  = false;
+                btn.textContent      = '🗑 Eliminar cita';
+                btn.style.background = '#fef2f2';
+                btn.style.color      = '#ef4444';
+                btn.style.border     = '1px solid #fecaca';
+            }, 3000);
+            return;
+        }
+
+        clearTimeout(this._confirmTimer);
+        this.disabled    = true;
+        this.textContent = 'Eliminando…';
+
+        fetch(`/citas/${citaActual.id}`, {
+            method: 'DELETE',
+            headers: {
+                'Accept':       'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+            },
+        })
+        .then(r => { if (!r.ok) throw new Error(); })
+        .then(() => {
+            citaActual.remove();
+            document.getElementById('modal-detalle-cita').classList.remove('open');
+        })
+        .catch(() => {
+            this.disabled        = false;
+            this._confirmPending = false;
+            this.textContent     = '🗑 Eliminar cita';
+            this.style.background = '#fef2f2';
+            this.style.color     = '#ef4444';
+            this.style.border    = '1px solid #fecaca';
+            alert('No se pudo eliminar la cita. Recarga la página e inténtalo de nuevo.');
+        });
+    });
+```
+
+- [ ] **Paso 2: Commit**
+
+```bash
+git add resources/views/citas/calendario.blade.php
+git commit -m "feat: eliminarCita double-confirm + cierre del modal de detalle"
+```
+
+---
+
+## Task 6: Push y verificación final
+
+- [ ] **Paso 1: Ejecutar la suite completa de citas**
+
+```bash
+C:/laragon/bin/php/php-8.3.30-Win32-vs16-x64/php.exe vendor/bin/phpunit tests/Feature/Citas/ tests/Unit/Services/CitaServiceTest.php --no-coverage
+```
+
+Esperado: todos los tests PASS.
+
+- [ ] **Paso 2: Push a develop**
+
+```bash
+git push origin develop
+```
+
+---
+
+## Notas de prueba manual
+
+1. Abrir `http://127.0.0.1:8080/calendario` como gestor
+2. Hacer clic en un evento → el modal muestra paciente, motivo, duración, notas y botones de estado
+3. Pulsar un botón de estado → el evento cambia de color en el calendario y el modal se cierra
+4. Abrir el mismo evento → el header muestra el nuevo estado
+5. Pulsar "Eliminar cita" una vez → el texto cambia a "¿Seguro? Clic para confirmar"
+6. Pulsar de nuevo → el evento desaparece del calendario
+7. Verificar que esperar 3 s sin confirmar revierte el botón al estado original

--- a/docs/superpowers/specs/2026-05-14-modal-detalle-cita-design.md
+++ b/docs/superpowers/specs/2026-05-14-modal-detalle-cita-design.md
@@ -1,0 +1,109 @@
+# Modal detalle de cita — spec
+
+**Fecha:** 2026-05-14
+**Contexto:** Calendario FullCalendar en `resources/views/citas/calendario.blade.php`
+
+## Problema
+
+`eventClick` abre un `alert()` nativo. No hay interfaz para ver el detalle de una cita existente ni para cambiar su estado o eliminarla. La ruta `PUT /citas/{cita}` y `DELETE /citas/{cita}` ya existen pero no tienen interfaz web.
+
+## Objetivo
+
+Flujo rápido al hacer clic en una cita del calendario:
+- Ver los datos clave (paciente, motivo, notas, fecha/hora)
+- Cambiar el estado con un solo clic
+- Eliminar la cita con confirmación de doble clic
+- Sin recarga de página; FullCalendar se actualiza en tiempo real
+
+## Diseño visual
+
+```
+┌─────────────────────────────────────────────────┐
+│  🟡 Pendiente  ·  Martes 20 mayo · 10:00–10:45  │  ← header con color de estado
+│                                               ×  │
+├─────────────────────────────────────────────────┤
+│  Paciente    García López, Juan              →   │  ← link a ficha (nueva pestaña)
+│  Motivo      Revisión semestral                  │
+│  Duración    45 min                              │
+│  Notas       —                                   │
+├─────────────────────────────────────────────────┤
+│  CAMBIAR ESTADO                                  │
+│  [Confirmar]  [Realizada]  [No presentado]       │
+│  [Cancelar]                                      │
+├─────────────────────────────────────────────────┤
+│                          [🗑 Eliminar cita]      │
+└─────────────────────────────────────────────────┘
+```
+
+- El estado actual **no** aparece como botón (ya está indicado en el header)
+- El header usa el mismo color que el evento en el calendario
+
+## Componentes
+
+### HTML (`calendario.blade.php`)
+
+Nuevo `<div class="modal-backdrop" id="modal-detalle-cita">` con la estructura del diseño visual. Sin `<form>`, toda la comunicación es vía `fetch`.
+
+### JS — abrir modal (`abrirModalDetalle(fcEvent)`)
+
+- Rellena los campos desde `fcEvent.extendedProps` (datos ya en memoria: `cliente_id`, `cliente_nombre`, `estado`, `motivo`) y `fcEvent.start`/`fcEvent.end`
+- Sin llamada al servidor al abrir — todo disponible en el evento FullCalendar
+- Guarda `fcEvent` en una variable de cierre para usarla en las acciones
+
+### JS — cambiar estado
+
+- Botones generados dinámicamente: los 5 estados menos el estado actual
+- Al pulsar: `fetch('/citas/{id}', { method: 'PUT', body: JSON.stringify({ estado }) })`
+- Headers: `Content-Type: application/json` + `X-CSRF-TOKEN` desde `<meta name="csrf-token">`
+- Mientras carga: botón deshabilitado con texto "Guardando…"
+- Al éxito: `fcEvent.setExtendedProp('estado', nuevoEstado)` + `fcEvent.setProp('color', COLORES_ESTADO[nuevoEstado])`, cierra modal
+
+### JS — eliminar
+
+- Primer clic: texto cambia a "¿Seguro? Clic para confirmar" (timeout 3 s para revertir)
+- Segundo clic dentro de los 3 s: `DELETE /citas/{id}` con `fetch`
+- Al éxito: `fcEvent.remove()`, cierra modal
+
+### Mapa de colores de estado (JS)
+
+```js
+const COLORES_ESTADO = {
+    pendiente:     '#f97316',
+    confirmada:    '#3b82f6',
+    realizada:     '#4ade80',
+    cancelada:     '#ef4444',
+    no_presentado: '#6b7280',
+};
+```
+
+Coincide con `$estadoColor` del modelo `Cita.php`.
+
+### Labels de estado (JS)
+
+```js
+const LABELS_ESTADO = {
+    pendiente:     'Pendiente',
+    confirmada:    'Confirmada',
+    realizada:     'Realizada',
+    cancelada:     'Cancelada',
+    no_presentado: 'No se presentó',
+};
+```
+
+## Cambios en backend
+
+**Ninguno.** `CitaController@update` y `CitaController@destroy` ya son correctos y aceptan peticiones JSON.
+
+## Cambios en frontend
+
+Solo `calendario.blade.php`:
+1. Nuevo bloque HTML: modal `#modal-detalle-cita`
+2. Nuevos estilos CSS: header de color, sección de estado, botón eliminar
+3. `eventClick`: sustituir `alert()` por llamada a `abrirModalDetalle(info.event)`
+4. Nuevas funciones JS: `abrirModalDetalle`, `cambiarEstadoCita`, `eliminarCita`
+
+## Fuera de alcance
+
+- Edición de fecha/hora, duración o motivo desde este modal (flujo rápido solicitado)
+- Notificaciones push al cambiar estado desde el calendario
+- Historial de cambios de estado

--- a/resources/views/citas/calendario.blade.php
+++ b/resources/views/citas/calendario.blade.php
@@ -512,6 +512,34 @@ function abrirModalDetalle(fcEvent) {
     document.getElementById('modal-detalle-cita').classList.add('open');
 }
 
+function cambiarEstadoCita(nuevoEstado, btn) {
+    if (!citaActual) return;
+    const textoOriginal = btn.textContent;
+    btn.disabled    = true;
+    btn.textContent = 'Guardando…';
+
+    fetch(`/citas/${citaActual.id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type':  'application/json',
+            'Accept':        'application/json',
+            'X-CSRF-TOKEN':  document.querySelector('meta[name="csrf-token"]').content,
+        },
+        body: JSON.stringify({ estado: nuevoEstado }),
+    })
+    .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+    .then(() => {
+        citaActual.setExtendedProp('estado', nuevoEstado);
+        citaActual.setProp('color', COLORES_ESTADO[nuevoEstado] || '#6b7280');
+        document.getElementById('modal-detalle-cita').classList.remove('open');
+    })
+    .catch(() => {
+        btn.disabled    = false;
+        btn.textContent = textoOriginal;
+        alert('No se pudo actualizar la cita. Recarga la página e inténtalo de nuevo.');
+    });
+}
+
 function abrirModalNuevaCita(date) {
     const input = document.getElementById('fc-fecha-input');
     if (date) {

--- a/resources/views/citas/calendario.blade.php
+++ b/resources/views/citas/calendario.blade.php
@@ -110,6 +110,59 @@
     padding: 8px 14px 13px;
     border-top: 1px solid #f1f5f9;
 }
+
+/* Modal detalle */
+#detalle-header { transition: background .2s; }
+#detalle-header .modal-close { color: rgba(255,255,255,.75); }
+#detalle-header .modal-close:hover { color: #fff; }
+.detalle-fila {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+.detalle-label {
+    color: #64748b;
+    font-size: .82rem;
+    width: 70px;
+    flex-shrink: 0;
+}
+.detalle-valor {
+    font-size: .9rem;
+    color: #1e293b;
+}
+.detalle-seccion {
+    border-top: 1px solid #f1f5f9;
+    padding-top: 14px;
+    margin-top: 14px;
+}
+.detalle-seccion-titulo {
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #94a3b8;
+    margin-bottom: 10px;
+}
+#detalle-botones-estado { display: flex; flex-wrap: wrap; gap: 6px; }
+.detalle-btn-estado {
+    font-size: .8rem;
+    padding: 5px 10px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #1e293b;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: opacity .15s;
+}
+.detalle-btn-estado:hover { opacity: .8; }
+.detalle-btn-estado:disabled { opacity: .5; cursor: not-allowed; }
+#detalle-btn-eliminar {
+    background: #fef2f2;
+    color: #ef4444;
+    border: 1px solid #fecaca;
+    font-size: .82rem;
+    transition: background .15s, color .15s;
+}
 </style>
 @endpush
 
@@ -132,6 +185,48 @@
                 style="width:100%;justify-content:center;font-size:.84rem;padding:7px 14px;">
             📅 Nueva cita
         </button>
+    </div>
+</div>
+
+{{-- ── MODAL detalle de cita ─────────────────────────────────────────────────────────── --}}
+<div class="modal-backdrop" id="modal-detalle-cita">
+    <div class="modal" style="max-width:440px;">
+        <div class="modal-header" id="detalle-header">
+            <div>
+                <span id="detalle-estado-badge"
+                      style="font-size:.78rem;opacity:.85;text-transform:uppercase;letter-spacing:.05em;display:block;margin-bottom:2px;"></span>
+                <span id="detalle-fecha" style="font-weight:600;font-size:.95rem;"></span>
+            </div>
+            <button class="modal-close" id="detalle-close">×</button>
+        </div>
+        <div style="padding:18px 22px 20px;">
+            <div class="detalle-fila">
+                <span class="detalle-label">Paciente</span>
+                <a id="detalle-paciente-link" href="#" target="_blank"
+                   style="font-weight:500;color:var(--primary);font-size:.9rem;text-decoration:none;"></a>
+            </div>
+            <div class="detalle-fila">
+                <span class="detalle-label">Motivo</span>
+                <span id="detalle-motivo" class="detalle-valor"></span>
+            </div>
+            <div class="detalle-fila">
+                <span class="detalle-label">Duración</span>
+                <span id="detalle-duracion" class="detalle-valor"></span>
+            </div>
+            <div class="detalle-fila" style="margin-bottom:0;">
+                <span class="detalle-label">Notas</span>
+                <span id="detalle-notas" class="detalle-valor" style="color:#64748b;font-style:italic;"></span>
+            </div>
+
+            <div class="detalle-seccion">
+                <p class="detalle-seccion-titulo">Cambiar estado</p>
+                <div id="detalle-botones-estado"></div>
+            </div>
+
+            <div class="detalle-seccion" style="display:flex;justify-content:flex-end;">
+                <button id="detalle-btn-eliminar" class="btn">🗑 Eliminar cita</button>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/resources/views/citas/calendario.blade.php
+++ b/resources/views/citas/calendario.blade.php
@@ -440,6 +440,64 @@ document.addEventListener('DOMContentLoaded', function () {
         abrirModalNuevaCita(selectedDate);
     });
 
+    // ── Modal detalle ─────────────────────────────────────────────────────────
+
+    document.getElementById('detalle-close').addEventListener('click', function() {
+        document.getElementById('modal-detalle-cita').classList.remove('open');
+    });
+
+    document.getElementById('modal-detalle-cita').addEventListener('click', function(e) {
+        if (e.target === this) this.classList.remove('open');
+    });
+
+    document.getElementById('detalle-btn-eliminar').addEventListener('click', function() {
+        if (!citaActual) return;
+
+        if (!this._confirmPending) {
+            this._confirmPending  = true;
+            this.textContent      = '¿Seguro? Clic para confirmar';
+            this.style.background = '#ef4444';
+            this.style.color      = '#fff';
+            this.style.border     = '1px solid #ef4444';
+
+            const btn = this;
+            btn._confirmTimer = setTimeout(() => {
+                btn._confirmPending  = false;
+                btn.textContent      = '🗑 Eliminar cita';
+                btn.style.background = '#fef2f2';
+                btn.style.color      = '#ef4444';
+                btn.style.border     = '1px solid #fecaca';
+            }, 3000);
+            return;
+        }
+
+        clearTimeout(this._confirmTimer);
+        this.disabled    = true;
+        this.textContent = 'Eliminando…';
+
+        fetch(`/citas/${citaActual.id}`, {
+            method: 'DELETE',
+            headers: {
+                'Accept':       'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+            },
+        })
+        .then(r => { if (!r.ok) throw new Error(); })
+        .then(() => {
+            citaActual.remove();
+            document.getElementById('modal-detalle-cita').classList.remove('open');
+        })
+        .catch(() => {
+            this.disabled        = false;
+            this._confirmPending = false;
+            this.textContent     = '🗑 Eliminar cita';
+            this.style.background = '#fef2f2';
+            this.style.color     = '#ef4444';
+            this.style.border    = '1px solid #fecaca';
+            alert('No se pudo eliminar la cita. Recarga la página e inténtalo de nuevo.');
+        });
+    });
+
     // ── Modal ─────────────────────────────────────────────────────────────────
 
     document.getElementById('modal-nueva-cita').addEventListener('click', function(e) {

--- a/resources/views/citas/calendario.blade.php
+++ b/resources/views/citas/calendario.blade.php
@@ -328,15 +328,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         eventClick: function(info) {
             info.jsEvent.stopPropagation();
-            const e = info.event;
-            const props = e.extendedProps;
-            const partes = e.title.split(' — ');
-            alert([
-                `Paciente: ${props.cliente_nombre}`,
-                `Motivo: ${partes[1] || partes[0]}`,
-                `Estado: ${props.estado}`,
-                `Inicio: ${e.start.toLocaleString('es-ES')}`,
-            ].join('\n'));
+            abrirModalDetalle(info.event);
         },
 
         dateClick: function(info) {
@@ -454,6 +446,71 @@ document.addEventListener('DOMContentLoaded', function () {
         if (e.target === this) this.classList.remove('open');
     });
 });
+
+const COLORES_ESTADO = {
+    pendiente:     '#f97316',
+    confirmada:    '#3b82f6',
+    realizada:     '#4ade80',
+    cancelada:     '#ef4444',
+    no_presentado: '#6b7280',
+};
+
+const LABELS_ESTADO = {
+    pendiente:     'Pendiente',
+    confirmada:    'Confirmada',
+    realizada:     'Realizada',
+    cancelada:     'Cancelada',
+    no_presentado: 'No se presentó',
+};
+
+let citaActual = null;
+
+function abrirModalDetalle(fcEvent) {
+    citaActual = fcEvent;
+    const props  = fcEvent.extendedProps;
+    const estado = props.estado;
+    const color  = COLORES_ESTADO[estado] || '#6b7280';
+
+    document.getElementById('detalle-header').style.background = color;
+    document.getElementById('detalle-estado-badge').textContent = LABELS_ESTADO[estado] || estado;
+
+    const optsDate = { weekday: 'long', day: 'numeric', month: 'long' };
+    const optsTime = { hour: '2-digit', minute: '2-digit' };
+    const fechaStr = fcEvent.start.toLocaleDateString('es-ES', optsDate);
+    const horaIni  = fcEvent.start.toLocaleTimeString('es-ES', optsTime);
+    const horaFin  = fcEvent.end ? fcEvent.end.toLocaleTimeString('es-ES', optsTime) : '';
+    document.getElementById('detalle-fecha').textContent =
+        horaFin ? `${fechaStr} · ${horaIni}–${horaFin}` : `${fechaStr} · ${horaIni}`;
+
+    const link = document.getElementById('detalle-paciente-link');
+    link.textContent = props.cliente_nombre;
+    link.href = `/clientes/${props.cliente_id}`;
+
+    document.getElementById('detalle-motivo').textContent = props.motivo || '—';
+    document.getElementById('detalle-notas').textContent  = props.notas  || '—';
+
+    const durMin = (fcEvent.end && fcEvent.start)
+        ? Math.round((fcEvent.end - fcEvent.start) / 60000)
+        : null;
+    document.getElementById('detalle-duracion').textContent = durMin ? `${durMin} min` : '—';
+
+    document.getElementById('detalle-botones-estado').innerHTML =
+        Object.entries(LABELS_ESTADO)
+            .filter(([key]) => key !== estado)
+            .map(([key, label]) =>
+                `<button class="detalle-btn-estado" onclick="cambiarEstadoCita('${key}', this)">${label}</button>`
+            ).join('');
+
+    const btnElim = document.getElementById('detalle-btn-eliminar');
+    btnElim.textContent         = '🗑 Eliminar cita';
+    btnElim.disabled            = false;
+    btnElim._confirmPending     = false;
+    btnElim.style.background    = '#fef2f2';
+    btnElim.style.color         = '#ef4444';
+    btnElim.style.border        = '1px solid #fecaca';
+
+    document.getElementById('modal-detalle-cita').classList.add('open');
+}
 
 function abrirModalNuevaCita(date) {
     const input = document.getElementById('fc-fecha-input');

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\AuthApiController;
 use App\Http\Controllers\Api\CitaApiController;
 use App\Http\Controllers\Api\ClienteApiController;
 use App\Http\Controllers\Api\DispositivoApiController;
+use App\Http\Controllers\Api\HistorialApiController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/login', [AuthApiController::class, 'login']);
@@ -17,9 +18,21 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Gestor only
     Route::middleware('gestor')->group(function () {
-        Route::get('/clientes', [ClienteApiController::class, 'index']);
-        Route::get('/citas/mes', [CitaApiController::class, 'mes']);
-        Route::patch('/citas/{cita}/estado', [CitaApiController::class, 'actualizarEstado']);
+        Route::get('/clientes',    [ClienteApiController::class, 'index']);
+        Route::post('/clientes',   [ClienteApiController::class, 'store']);
+        Route::put('/clientes/{cliente}',    [ClienteApiController::class, 'update']);
+        Route::delete('/clientes/{cliente}', [ClienteApiController::class, 'destroy']);
+
+        Route::post('/clientes/{cliente}/dentadura', [ClienteApiController::class, 'actualizarDentadura']);
+
+        Route::post('/clientes/{cliente}/historial',  [HistorialApiController::class, 'store']);
+        Route::put('/historial/{historial}',          [HistorialApiController::class, 'update']);
+        Route::delete('/historial/{historial}',       [HistorialApiController::class, 'destroy']);
+
+        Route::get('/citas/mes',                [CitaApiController::class, 'mes']);
+        Route::put('/citas/{cita}',             [CitaApiController::class, 'update']);
+        Route::delete('/citas/{cita}',          [CitaApiController::class, 'destroy']);
+        Route::patch('/citas/{cita}/estado',    [CitaApiController::class, 'actualizarEstado']);
     });
 
     // Gestor o propietario del cliente

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,5 +26,6 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::middleware('gestor.o.propietario')->group(function () {
         Route::get('/clientes/{cliente}',           [ClienteApiController::class, 'show']);
         Route::get('/clientes/{cliente}/historial', [ClienteApiController::class, 'historial']);
+        Route::get('/clientes/{cliente}/dentadura', [ClienteApiController::class, 'dentadura']);
     });
 });

--- a/tests/Feature/Api/ApiCitasTest.php
+++ b/tests/Feature/Api/ApiCitasTest.php
@@ -120,4 +120,55 @@ class ApiCitasTest extends TestCase
             'estado' => 'cancelada',
         ])->assertForbidden();
     }
+
+    public function test_gestor_puede_actualizar_cita(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->putJson("/api/citas/{$cita->id}", [
+            'motivo' => 'Motivo actualizado',
+            'notas'  => 'Notas de prueba',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('citas', ['id' => $cita->id, 'motivo' => 'Motivo actualizado']);
+    }
+
+    public function test_cliente_no_puede_actualizar_cita(): void
+    {
+        $user    = User::factory()->create(['role' => 'cliente']);
+        $cliente = Cliente::factory()->create(['user_id' => $user->id]);
+        $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+        $token   = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->putJson("/api/citas/{$cita->id}", [
+            'motivo' => 'Intento de cambio',
+        ])->assertForbidden();
+    }
+
+    public function test_gestor_puede_eliminar_cita(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->deleteJson("/api/citas/{$cita->id}")
+             ->assertOk()
+             ->assertJson(['ok' => true]);
+
+        $this->assertDatabaseMissing('citas', ['id' => $cita->id]);
+    }
+
+    public function test_cliente_no_puede_eliminar_cita(): void
+    {
+        $user    = User::factory()->create(['role' => 'cliente']);
+        $cliente = Cliente::factory()->create(['user_id' => $user->id]);
+        $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+        $token   = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->deleteJson("/api/citas/{$cita->id}")->assertForbidden();
+    }
 }

--- a/tests/Feature/Api/ApiClientesTest.php
+++ b/tests/Feature/Api/ApiClientesTest.php
@@ -96,4 +96,31 @@ class ApiClientesTest extends TestCase
 
         $this->withToken($token)->getJson("/api/clientes/{$ajeno->id}/historial")->assertForbidden();
     }
+
+    public function test_gestor_puede_ver_dentadura(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->getJson("/api/clientes/{$cliente->id}/dentadura")->assertOk();
+    }
+
+    public function test_propietario_puede_ver_su_dentadura(): void
+    {
+        $user    = User::factory()->create(['role' => 'cliente']);
+        $cliente = Cliente::factory()->create(['user_id' => $user->id]);
+        $token   = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->getJson("/api/clientes/{$cliente->id}/dentadura")->assertOk();
+    }
+
+    public function test_otro_cliente_no_puede_ver_dentadura_ajena(): void
+    {
+        $user  = User::factory()->create(['role' => 'cliente']);
+        $ajeno = Cliente::factory()->create();
+        $token = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->getJson("/api/clientes/{$ajeno->id}/dentadura")->assertForbidden();
+    }
 }

--- a/tests/Feature/Api/ApiClientesTest.php
+++ b/tests/Feature/Api/ApiClientesTest.php
@@ -123,4 +123,93 @@ class ApiClientesTest extends TestCase
 
         $this->withToken($token)->getJson("/api/clientes/{$ajeno->id}/dentadura")->assertForbidden();
     }
+
+    public function test_gestor_puede_crear_cliente(): void
+    {
+        $gestor = User::factory()->gestor()->create();
+        $token  = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson('/api/clientes', [
+            'apellidos' => 'García López',
+            'nombre'    => 'Juan',
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('clientes', ['apellidos' => 'García López', 'nombre' => 'Juan']);
+    }
+
+    public function test_crear_cliente_inicializa_dentadura(): void
+    {
+        $gestor = User::factory()->gestor()->create();
+        $token  = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson('/api/clientes', [
+            'apellidos' => 'Pérez',
+            'nombre'    => 'Ana',
+        ])->assertCreated();
+
+        $cliente = Cliente::where('apellidos', 'Pérez')->first();
+        $this->assertSame(32, $cliente->dentadura()->count());
+    }
+
+    public function test_cliente_no_puede_crear_cliente(): void
+    {
+        $user  = User::factory()->create(['role' => 'cliente']);
+        $token = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson('/api/clientes', [
+            'apellidos' => 'Test',
+            'nombre'    => 'Test',
+        ])->assertForbidden();
+    }
+
+    public function test_gestor_puede_actualizar_cliente(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create(['apellidos' => 'Antiguo']);
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->putJson("/api/clientes/{$cliente->id}", [
+            'apellidos' => 'Nuevo',
+            'nombre'    => $cliente->nombre,
+        ])->assertOk();
+
+        $this->assertDatabaseHas('clientes', ['id' => $cliente->id, 'apellidos' => 'Nuevo']);
+    }
+
+    public function test_gestor_puede_eliminar_cliente(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->deleteJson("/api/clientes/{$cliente->id}")
+             ->assertOk()
+             ->assertJson(['ok' => true]);
+
+        $this->assertSoftDeleted('clientes', ['id' => $cliente->id]);
+    }
+
+    public function test_gestor_puede_actualizar_dentadura(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        \App\Models\Dentadura::factory()->create([
+            'cliente_id' => $cliente->id,
+            'num_diente' => '16',
+        ]);
+
+        $this->withToken($token)->postJson("/api/clientes/{$cliente->id}/dentadura", [
+            'dientes' => [
+                ['num_diente' => '16', 'estado_pieza' => 'corona'],
+            ],
+        ])->assertOk()->assertJson(['ok' => true]);
+
+        $this->assertDatabaseHas('dentadura', [
+            'cliente_id'   => $cliente->id,
+            'num_diente'   => '16',
+            'estado_pieza' => 'corona',
+        ]);
+    }
 }

--- a/tests/Feature/Api/ApiHistorialTest.php
+++ b/tests/Feature/Api/ApiHistorialTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Cliente;
+use App\Models\HistorialClinico;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiHistorialTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_gestor_puede_crear_historial(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson("/api/clientes/{$cliente->id}/historial", [
+            'dia'         => 10,
+            'mes'         => 5,
+            'anio'        => 2026,
+            'diagnostico' => 'Caries en diente 16',
+            'debe'        => 120.00,
+            'haber'       => 120.00,
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('historial_clinico', [
+            'cliente_id'  => $cliente->id,
+            'diagnostico' => 'Caries en diente 16',
+        ]);
+    }
+
+    public function test_cliente_no_puede_crear_historial(): void
+    {
+        $user    = User::factory()->create(['role' => 'cliente']);
+        $cliente = Cliente::factory()->create(['user_id' => $user->id]);
+        $token   = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson("/api/clientes/{$cliente->id}/historial", [
+            'dia'         => 10,
+            'mes'         => 5,
+            'anio'        => 2026,
+            'diagnostico' => 'Test',
+        ])->assertForbidden();
+    }
+
+    public function test_fecha_invalida_falla_validacion(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $token   = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->postJson("/api/clientes/{$cliente->id}/historial", [
+            'dia'         => 31,
+            'mes'         => 2,
+            'anio'        => 2026,
+            'diagnostico' => 'Test',
+        ])->assertUnprocessable();
+    }
+
+    public function test_gestor_puede_actualizar_historial(): void
+    {
+        $gestor   = User::factory()->gestor()->create();
+        $cliente  = Cliente::factory()->create();
+        $historial = HistorialClinico::factory()->create(['cliente_id' => $cliente->id]);
+        $token    = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->putJson("/api/historial/{$historial->id}", [
+            'dia'         => $historial->dia,
+            'mes'         => $historial->mes,
+            'anio'        => $historial->anio,
+            'diagnostico' => 'Diagnóstico actualizado',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('historial_clinico', [
+            'id'          => $historial->id,
+            'diagnostico' => 'Diagnóstico actualizado',
+        ]);
+    }
+
+    public function test_gestor_puede_eliminar_historial(): void
+    {
+        $gestor   = User::factory()->gestor()->create();
+        $cliente  = Cliente::factory()->create();
+        $historial = HistorialClinico::factory()->create(['cliente_id' => $cliente->id]);
+        $token    = $gestor->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->deleteJson("/api/historial/{$historial->id}")
+             ->assertOk()
+             ->assertJson(['ok' => true]);
+
+        $this->assertDatabaseMissing('historial_clinico', ['id' => $historial->id]);
+    }
+
+    public function test_cliente_no_puede_eliminar_historial(): void
+    {
+        $user     = User::factory()->create(['role' => 'cliente']);
+        $cliente  = Cliente::factory()->create(['user_id' => $user->id]);
+        $historial = HistorialClinico::factory()->create(['cliente_id' => $cliente->id]);
+        $token    = $user->createToken('app')->plainTextToken;
+
+        $this->withToken($token)->deleteJson("/api/historial/{$historial->id}")->assertForbidden();
+    }
+}

--- a/tests/Feature/Citas/CitaTest.php
+++ b/tests/Feature/Citas/CitaTest.php
@@ -103,6 +103,20 @@ class CitaTest extends TestCase
         $this->assertDatabaseMissing('citas', ['id' => $cita->id]);
     }
 
+    public function test_gestor_puede_eliminar_cita_via_json(): void
+    {
+        $gestor  = User::factory()->gestor()->create();
+        $cliente = Cliente::factory()->create();
+        $cita    = Cita::factory()->create(['cliente_id' => $cliente->id]);
+
+        $this->actingAs($gestor)
+             ->deleteJson(route('citas.destroy', $cita))
+             ->assertOk()
+             ->assertJson(['ok' => true]);
+
+        $this->assertDatabaseMissing('citas', ['id' => $cita->id]);
+    }
+
     public function test_api_mes_devuelve_json_fullcalendar(): void
     {
         $gestor  = User::factory()->gestor()->create();

--- a/tests/Feature/Clientes/DentaduraEndpointEstadosTest.php
+++ b/tests/Feature/Clientes/DentaduraEndpointEstadosTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Clientes;
 
 use App\Models\Cliente;
 use App\Models\Dentadura;

--- a/tests/Feature/Clientes/DentaduraEstadosNuevosTest.php
+++ b/tests/Feature/Clientes/DentaduraEstadosNuevosTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Clientes;
 
 use App\Models\Dentadura;
 use Tests\TestCase;

--- a/tests/Unit/Models/CitaModelTest.php
+++ b/tests/Unit/Models/CitaModelTest.php
@@ -43,18 +43,6 @@ class CitaModelTest extends TestCase
         }
     }
 
-    public function test_scope_del_mes_solo_devuelve_citas_de_ese_mes(): void
-    {
-        $cliente = Cliente::factory()->create();
-        Cita::factory()->create(['cliente_id' => $cliente->id, 'fecha_hora' => '2026-05-15 10:00:00', 'estado' => 'confirmada']);
-        Cita::factory()->create(['cliente_id' => $cliente->id, 'fecha_hora' => '2026-06-10 10:00:00', 'estado' => 'confirmada']);
-
-        $resultado = Cita::delMes(2026, 5)->get();
-
-        $this->assertCount(1, $resultado);
-        $this->assertSame('2026-05-15', $resultado->first()->fecha_hora->format('Y-m-d'));
-    }
-
     public function test_scope_proximas_excluye_pasadas_y_finalizadas(): void
     {
         $cliente = Cliente::factory()->create();

--- a/tests/Unit/Services/CitaServiceTest.php
+++ b/tests/Unit/Services/CitaServiceTest.php
@@ -49,7 +49,7 @@ class CitaServiceTest extends TestCase
         $this->assertDatabaseHas('citas', ['id' => $cita->id, 'estado' => 'confirmada']);
     }
 
-    public function test_citas_del_mes_retorna_formato_fullcalendar(): void
+    public function test_citas_por_rango_retorna_formato_fullcalendar(): void
     {
         $cliente = Cliente::factory()->create();
         Cita::factory()->create([
@@ -59,7 +59,9 @@ class CitaServiceTest extends TestCase
             'estado'     => 'confirmada',
         ]);
 
-        $resultado = $this->service->citasDelMes(now()->year, now()->month);
+        $start    = now()->startOfMonth()->toDateString();
+        $end      = now()->endOfMonth()->addDay()->toDateString();
+        $resultado = $this->service->citasPorRango($start, $end);
 
         $this->assertCount(1, $resultado);
         $this->assertArrayHasKey('title', $resultado->first());


### PR DESCRIPTION
## Resumen

- **API Android completa**: 9 endpoints nuevos (clientes CRUD, historial CRUD, citas update/delete, odontograma)
- **Modal detalle de cita**: reemplaza `alert()` en `eventClick` con modal de cambio de estado y eliminación con doble confirmación
- **Migración API citas**: unifica parámetros `start/end` en lugar de `year/month`
- **Tests**: 15 tests nuevos en `ApiClientesTest`, `ApiCitasTest` y `ApiHistorialTest`
- **Refactor**: tests de dentadura movidos a `tests/Feature/Clientes/`, limpieza de código muerto
- **Documentación**: `docs/api-mobile-spec.md` — especificación completa de la API para el equipo móvil

## Commits incluidos

- feat(api): store/update/destroy clientes, historial y citas
- feat(api): GET /api/clientes/{id}/dentadura
- feat: modal detalle de cita con cambio de estado y eliminación
- fix: Carbon copy() en citasPorRango; Request inyectado en destroy
- refactor: unificar API citas a start/end, eliminar citasDelMes
- docs: spec API móvil completa

🤖 Generated with [Claude Code](https://claude.com/claude-code)